### PR TITLE
Change in Runtime Extension class

### DIFF
--- a/org.imixs.eclipse.bpmn2.plugin/src/org/imixs/bpmn/ImixsRuntimeExtension.java
+++ b/org.imixs.eclipse.bpmn2.plugin/src/org/imixs/bpmn/ImixsRuntimeExtension.java
@@ -1,15 +1,14 @@
 package org.imixs.bpmn;
 
-import org.eclipse.bpmn2.modeler.core.IBpmn2RuntimeExtension;
 import org.eclipse.bpmn2.modeler.core.LifecycleEvent;
 import org.eclipse.bpmn2.modeler.core.LifecycleEvent.EventType;
 import org.eclipse.bpmn2.modeler.core.utils.ModelUtil.Bpmn2DiagramType;
-import org.eclipse.bpmn2.modeler.ui.DefaultBpmn2RuntimeExtension.RootElementParser;
 import org.eclipse.bpmn2.modeler.ui.wizards.FileService;
+import org.eclipse.bpmn2.modeler.ui.AbstractBpmn2RuntimeExtension;
 import org.eclipse.ui.IEditorInput;
 import org.xml.sax.InputSource;
 
-public class ImixsRuntimeExtension implements IBpmn2RuntimeExtension {
+public class ImixsRuntimeExtension extends AbstractBpmn2RuntimeExtension {
 
 	public static final String RUNTIME_ID = "org.imixs.workflow.bpmn.runtime";
 


### PR DESCRIPTION
... because of API change in org.eclipse.bpmn2.modeler.ui: RootElementParser has moved to the
abstract base class AbstractBpmn2RuntimeExtension.
